### PR TITLE
Don't depend on `[!Default; 0]: Default` impl

### DIFF
--- a/tuplez-macros/src/lib.rs
+++ b/tuplez-macros/src/lib.rs
@@ -32,7 +32,7 @@ pub fn tuple_traits_impl(input: TokenStream) -> TokenStream {
             type Iter<'a> = std::array::IntoIter<&'a T, 0> where Self: 'a, T: 'a;
             type IterMut<'a> = std::array::IntoIter<&'a mut T, 0> where Self: 'a, T: 'a;
             fn to_array(self) -> Self::Array {
-                Default::default()
+                []
             }
             fn iter<'a>(&'a self) -> Self::Iter<'a>
             where


### PR DESCRIPTION
There are plans to remove the unconditional `[T; 0]: Default` impl (where `T` doesn't necessarily implement `Default`) from the standard library (see https://github.com/rust-lang/rust/pull/145457). That is a breaking change that would affect this crate.

This PR fixes this by removing a dependency on that impl.
